### PR TITLE
Add option to buffer response body instead of streaming directly to client

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 engine-strict=true
-registry=https://npm.pkg.github.com/erwinvil
+registry=https://npm.pkg.github.com/erwinv

--- a/README.md
+++ b/README.md
@@ -10,30 +10,16 @@ npm install --save @erwinv/koa-http-proxy
 ## Usage
 
 ```typescript
-import {
-  KoaHttpProxy,
-  StateWithProxyOpts,
-  BufferResponseBody,
-} from '@erwinv/koa-http-proxy'
+import { KoaHttpProxy } from '@erwinv/koa-http-proxy'
 
 import { default as Koa, Middleware } from 'koa'
 
 new Koa()
-  .use((async (ctx, next) => {
-    const authMissing = (ctx.get('Authorization')?.trim() ?? '') === ''
-
-    if (authMissing) {
-      ctx.state.proxyOpts = {
-        headers: { Authorization: `Basic ${process.env.PROXY_AUTH}`},
-      }
-    }
-
-    return next()
-  }) as Middleware<StateWithProxyOpts>)
-  .use(KoaHttpProxy({
-    target: process.env.PROXY_TARGET,
+  .use(KoaHttpProxy(process.env.PROXY_TARGET, {
     xfwd: true,
+    changeOrigin: true,
+    followRedirects: true,
     proxyTimeout: 60 * 1000,
-  }, true))
+  }))
   .listen(process.env.PORT)
 ```

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ new Koa()
 
     return next()
   }) as Middleware<StateWithProxyOpts>)
-  // .use(BufferResponseBody()) // to buffer the response.body stream into a Buffer
-  .use(KoaHttpProxy(new URL(process.env.PROXY_TARGET), {
-    xfwd: process.env.PROXY_TARGET_IS_EXTERNAL?.toLowerCase() !== 'true',
+  .use(KoaHttpProxy({
+    target: process.env.PROXY_TARGET,
+    xfwd: true,
     proxyTimeout: 60 * 1000,
-  }))
+  }, true))
   .listen(process.env.PORT)
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install --save @erwinv/koa-http-proxy
 import {
   KoaHttpProxy,
   StateWithProxyOpts,
+  BufferResponseBody,
 } from '@erwinv/koa-http-proxy'
 
 import { default as Koa, Middleware } from 'koa'
@@ -29,6 +30,7 @@ new Koa()
 
     return next()
   }) as Middleware<StateWithProxyOpts>)
+  // .use(BufferResponseBody()) // to buffer the response.body stream into a Buffer
   .use(KoaHttpProxy(new URL(process.env.PROXY_TARGET), {
     xfwd: process.env.PROXY_TARGET_IS_EXTERNAL?.toLowerCase() !== 'true',
     proxyTimeout: 60 * 1000,

--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ new Koa()
   }))
   .listen(process.env.PORT)
 ```
+
+## Options
+
+### Inherited from third-party dependency
+
+These options are the same as those of [http-party/node-http-proxy](https://github.com/http-party/node-http-proxy#options) with the following exceptions:
+
+- `target`: same type but is moved outside of the options object and should be passed as first argument to the middleware factory function instead
+- `ws`: WebSockets not supported
+- `selfHandleResponse`: not supported (middleware internals depends on this being always false)
+
+### Own
+
+- `bufferResponseBody`: boolean, default: false - if true, the proxied response will be buffered in full before sending it to client (useful for proxies that need to modify/decorate the JSON response body for example). Otherwise (if false), the proxied response is streamed directly to the client. Note: the buffered response body is a `Buffer` and may need to be decompressed (depending on `Content-Encoding`), stringified, and/or parsed (depending on `Content-Type`) before it can be read or modified.

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 export {
   HttpProxyMiddleware as KoaHttpProxy,
   StateWithProxyOpts,
+  BufferResponseBody,
 } from './lib/koa-http-proxy'
 
 export {

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,6 @@
 export {
   HttpProxyMiddleware as KoaHttpProxy,
   StateWithProxyOpts,
-  BufferResponseBody,
 } from './lib/koa-http-proxy'
 
 export {

--- a/lib/koa-http-proxy.ts
+++ b/lib/koa-http-proxy.ts
@@ -3,7 +3,7 @@ import { OutgoingMessage, ServerResponse } from 'http'
 import { PassThrough, Readable } from 'stream'
 
 import { Middleware, Request, Response, DefaultState } from 'koa'
-import { createProxy } from 'http-proxy'
+import { createProxy, ServerOptions as ProxyOpts } from 'http-proxy'
 
 import {
   MiddlewareOpts,
@@ -19,8 +19,13 @@ export interface StateWithProxyOpts extends DefaultState {
   proxyOpts?: MiddlewareOpts & UnsupportedOpts
 }
 
-export function HttpProxyMiddleware(opts: InitOpts, bufferRespBody = false): Middleware<StateWithProxyOpts> {
-  const proxy = createProxy(opts) // opts set at init/start-up
+type ProxyTarget = NonNullable<ProxyOpts['target']>
+
+export function HttpProxyMiddleware(target: ProxyTarget, opts: InitOpts, bufferRespBody = false): Middleware<StateWithProxyOpts> {
+  const proxy = createProxy({
+    ...opts, // opts set at init/start-up
+    target,
+  })
 
   return async (ctx, next) => {
     const [opts, unsupportedOpts] = partitionSupportedOpts(ctx.state.proxyOpts)

--- a/lib/opts.ts
+++ b/lib/opts.ts
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import { ServerOptions as ProxyOpts } from 'http-proxy'
 
 const supportedOpts = [
-  'target',
+  // 'target',
   'forward', // https://github.com/http-party/node-http-proxy/issues/773
   'agent',
   'ssl',
@@ -30,7 +30,7 @@ const supportedOpts = [
 ] as const
 
 export type MiddlewareOpts = Pick<ProxyOpts, typeof supportedOpts[number]>
-export type InitOpts = Required<Pick<MiddlewareOpts, 'target'>> & Omit<MiddlewareOpts, 'target' | 'buffer'>
+export type InitOpts = Omit<MiddlewareOpts, 'buffer'>
 export type UnsupportedOpts = Record<string, any>
 
 export function partitionSupportedOpts(opts?: MiddlewareOpts & UnsupportedOpts): readonly [MiddlewareOpts, UnsupportedOpts] {

--- a/lib/opts.ts
+++ b/lib/opts.ts
@@ -29,8 +29,9 @@ const supportedOpts = [
   'buffer',
 ] as const
 
-export type MiddlewareOpts = Pick<ProxyOpts, typeof supportedOpts[number]>
-export type InitOpts = Omit<MiddlewareOpts, 'buffer'>
+export type MiddlewareOpts = Pick<ProxyOpts, typeof supportedOpts[number]> & {
+  bufferResponseBody?: boolean
+}
 export type UnsupportedOpts = Record<string, any>
 
 export function partitionSupportedOpts(opts?: MiddlewareOpts & UnsupportedOpts): readonly [MiddlewareOpts, UnsupportedOpts] {

--- a/lib/opts.ts
+++ b/lib/opts.ts
@@ -2,8 +2,8 @@ import _ from 'lodash'
 import { ServerOptions as ProxyOpts } from 'http-proxy'
 
 const supportedOpts = [
-  // 'target',
-  // 'forward', // https://github.com/http-party/node-http-proxy/issues/773
+  'target',
+  'forward', // https://github.com/http-party/node-http-proxy/issues/773
   'agent',
   'ssl',
   // 'ws',
@@ -26,19 +26,12 @@ const supportedOpts = [
   'timeout',
   'followRedirects',
   // 'selfHandleResponse',
-  // 'buffer',
+  'buffer',
 ] as const
 
 export type MiddlewareOpts = Pick<ProxyOpts, typeof supportedOpts[number]>
+export type InitOpts = Required<Pick<MiddlewareOpts, 'target'>> & Omit<MiddlewareOpts, 'target' | 'buffer'>
 export type UnsupportedOpts = Record<string, any>
-
-export const hardcodedOpts: ProxyOpts = {
-  ws: false,
-}
-
-export const defaultOpts: MiddlewareOpts = {
-  xfwd: true,
-}
 
 export function partitionSupportedOpts(opts?: MiddlewareOpts & UnsupportedOpts): readonly [MiddlewareOpts, UnsupportedOpts] {
   return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@erwinvil/koa-http-proxy",
+  "name": "@erwinv/koa-http-proxy",
   "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@erwinvil/koa-http-proxy",
+  "name": "@erwinv/koa-http-proxy",
   "version": "1.1.2",
   "description": "Koa HTTP proxy middleware powered by http-party/node-http-proxy.",
   "main": "build/index.js",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/erwinvil/koa-http-proxy.git"
+    "url": "git+https://github.com/erwinv/koa-http-proxy.git"
   },
   "keywords": [
     "reverse",
@@ -24,9 +24,9 @@
   "author": "Erwin Villejo",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/erwinvil/koa-http-proxy/issues"
+    "url": "https://github.com/erwinv/koa-http-proxy/issues"
   },
-  "homepage": "https://github.com/erwinvil/koa-http-proxy#readme",
+  "homepage": "https://github.com/erwinv/koa-http-proxy#readme",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
By default, the response from the proxy target is streamed directly to the client. This option adds the capability to buffer the response from the target in full, before forwarding it to the client, similar to the [`proxy_buffering on;` option in NGINX](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering).

This is useful for proxies that need to modify/decorate the response before forwarding it to the client.

Note that the buffered response body is a `Buffer` and may need to be decompressed (depending on `Content-Encoding`), stringified, and/or parsed (depending on `Content-Type`) before it can be read or modified.